### PR TITLE
fix types.h guard

### DIFF
--- a/H/types.h
+++ b/H/types.h
@@ -1,7 +1,7 @@
 
 /* prototypes of TYPES.C */
 
-#ifndef _TYPES_H_INCLUDED
+#ifndef _TYPES_H_INCLUDED_
 #define _TYPES_H_INCLUDED_
 
 /* qualified_type us used for parsing a qualified type. */


### PR DESCRIPTION
Typo in the types.h define guard, `_TYPES_H_INCLUDED` is used instead of `_TYPES_H_INCLUDED_`