### PR TITLE
fix inline comment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ bld/
 [Ll]og/
 
 testers/
+GccMacR/
+GccMacD/
 GccUnixR/
 GccUnixD/
 MinGW-w64R/
@@ -275,3 +277,7 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+
+# macOS forks
+.DS_Store
+

--- a/H/instruct.h
+++ b/H/instruct.h
@@ -1240,7 +1240,8 @@ insx(SWAPGS, swapgs,            OpCls( NONE,     NONE,       NONE ), F_0F,   0, 
 insx(SYSCALL_, syscall,         OpCls( NONE,     NONE,       NONE ), F_0F,   0,  no_RM,  0x05,     0x00,       P_64,       0,        RWF_X64)
 insx(SYSRET, sysret,            OpCls( NONE,     NONE,       NONE ), F_0F,   0,  no_RM,  0x07,     0x00,       P_64,       0,        RWF_X64)
 
-/* #if 0 /* v2.09: added, inactive ( not supported by ML64 v8,9,10 ) */
+/* #if 0 */
+/* v2.09: added, inactive ( not supported by ML64 v8,9,10 ) */
 insx(FXRSTOR64, fxrstor64,      OpCls( M_ANY,    NONE,       NONE ), F_480F, 0,  no_WDS, 0xAE,     0x08,       P_64,       0,        RWF_X64)
 insx(FXSAVE64, fxsave64,        OpCls( M_ANY,    NONE,       NONE ), F_480F, 0,  no_WDS, 0xAE,     0x00,       P_64,       0,        RWF_X64)
 #if SSE4SUPP


### PR DESCRIPTION
Fix comment line with extra `/*` in it.
This fixes gcc/clang warning ('/*' within block comment).