### PR TITLE
Restore DJGPP support from JWasm

### DIFF
--- a/H/globals.h
+++ b/H/globals.h
@@ -287,6 +287,7 @@ enum sformat
     SFORMAT_NONE,
     SFORMAT_MZ,    /* MZ binary */
     SFORMAT_PE,    /* PE (32- or 64-bit) binary */
+    SFORMAT_DJGPP, /* Djgpp variant of COFF */
     SFORMAT_64BIT, /* 64bit COFF or ELF */
 };
 

--- a/Makefile-Linux-GCC-64.mak
+++ b/Makefile-Linux-GCC-64.mak
@@ -7,6 +7,10 @@ ifndef DEBUG
 DEBUG=0
 endif
 
+ifndef DJGPP
+DJGPP=0
+endif
+
 inc_dirs  = -IH
 
 #cflags stuff
@@ -17,6 +21,10 @@ OUTD=GccUnixR
 else
 extra_c_flags = -DDEBUG_OUT -g
 OUTD=GccUnixD
+endif
+
+ifneq ($(DJGPP), 0)
+extra_c_flags += -DDJGPP_SUPPORT=1
 endif
 
 c_flags =-D __UNIX__ $(extra_c_flags)

--- a/Makefile-OSX-Clang-64.mak
+++ b/Makefile-OSX-Clang-64.mak
@@ -7,6 +7,10 @@ ifndef DEBUG
 DEBUG=0
 endif
 
+ifndef DJGPP
+DJGPP=0
+endif
+
 inc_dirs  = -IH
 
 #cflags stuff
@@ -17,6 +21,10 @@ OUTD=GccUnixR
 else
 extra_c_flags = -DDEBUG_OUT -g
 OUTD=GccUnixD
+endif
+
+ifneq ($(DJGPP), 0)
+extra_c_flags += -DDJGPP_SUPPORT=1
 endif
 
 c_flags =-D __UNIX__ $(extra_c_flags)

--- a/fixup.c
+++ b/fixup.c
@@ -245,7 +245,7 @@ void store_fixup( struct fixup *fixup, struct dsym *seg, int_32 *pdata )
             } else if ( fixup->type == FIX_OFF32 ) {
                 *pdata += fixup->sym->offset;
                 fixup->offset += fixup->sym->offset; /* ok? */
-                fixup->segment = fixup->sym->segment;/* ok? */
+                fixup->segment_var = fixup->sym->segment;/* ok? */
             }
         } else
 #endif


### PR DESCRIPTION
Restore DJGPP support. Just needs a few bits and pieces from [JWasm](https://github.com/JWasm/JWasm).

I can squash these together if you'd prefer.

Tested and working in https://github.com/BlazingRenderer/BRender/ as of https://github.com/BlazingRenderer/BRender/commit/9cbabc478369f15c8634c26d18f7fbf77460af82